### PR TITLE
fix: Removed default value for create attachment var

### DIFF
--- a/aws/elb_attachment/variables.tf
+++ b/aws/elb_attachment/variables.tf
@@ -1,7 +1,6 @@
 variable "create_attachment" {
   description = "Create the elb attachment or not"
   type        = bool
-  default     = true
 }
 
 variable "number_of_instances" {


### PR DESCRIPTION
Removed default variable value in create_attachment variable to avoid creating elb attachment